### PR TITLE
fix logo header in small mode

### DIFF
--- a/style/sidebar.scss
+++ b/style/sidebar.scss
@@ -19,7 +19,7 @@ $sidebar-color: rgba(90%, 90%, 90%, 100%);
 	}
 
 	.user-widget {
-		margin-top: 35px;
+		margin-top: 85px;
 
 		img {
 			width: 50px;
@@ -34,6 +34,8 @@ $sidebar-color: rgba(90%, 90%, 90%, 100%);
 		background-color: $sidebar-header-bg;
 		padding: 15px 15px 13px 15px;
 		font-size: 17px;
+		position: fixed;
+		width: 200px;
 
 		img {
 			vertical-align: top;


### PR DESCRIPTION
This makes it so the logo stays visible in small mode
![image](https://cloud.githubusercontent.com/assets/6258213/23577027/f3b9adb2-0108-11e7-8347-f53895b944f5.png)
Doesn't completely fix it in supa-small mode though.
![image](https://cloud.githubusercontent.com/assets/6258213/23577033/190d87b4-0109-11e7-8c3f-4ebff2351685.png)

still looks better though I think.